### PR TITLE
some date updates

### DIFF
--- a/src/filters/w3-date-filter.js
+++ b/src/filters/w3-date-filter.js
@@ -1,5 +1,15 @@
-module.exports = function w3cDate(value) {
-  const dateObject = new Date(value);
+module.exports = function w3cDate(date) {
+  let dateObject = new Date(date);
+
+  // If the date is invalid, try to parse it from the file slug
+  if (dateObject instanceof Date && isNaN(dateObject)) {
+    // Some of the dates are the file slug passed in
+    if (date.includes('.')) {
+      date = date.split('.')[0];
+
+      dateObject = new Date(date);
+    }
+  }
 
   return dateObject.toISOString();
 };

--- a/src/wp.njk
+++ b/src/wp.njk
@@ -34,17 +34,28 @@ xmlns:wp="http://wordpress.org/export/1.2/"
     <wp:term_name><![CDATA[Uncategorized]]></wp:term_name>
   </wp:term>
   <generator>https://wordpress.org/?v=5.8.1</generator>
-  {% for post in collections.posts %}
+  {%- for post in collections.posts -%}
+
+
+  {% set postDate = post.data.date %}
+
+  {# Some Posts don't have dates, use the fileSlug to get the date out of the name </fingers-crossed> #}
+  {% if post.data.date  %}
+  {% else %}
+  {% set postDate = post.fileSlug %}
+  {% endif %}
+  {{ postDate | log }}
+
   <item>
     <title><![CDATA[{{ post.date }}]]></title>
     <link>https://chrisenns.com/{{ post.fileSlug }}/</link>
-    <pubDate>{{ post.data.title }}</pubDate>
+    <pubDate>{{ postDate | w3DateFilter }}</pubDate>
     <dc:creator><![CDATA[test]]></dc:creator>
     <description></description>
     <content:encoded><![CDATA[{{ post_name.templateContent | safe }}]]></content:encoded>
     <excerpt:encoded><![CDATA[]]></excerpt:encoded>
     <wp:post_id>{{ loop.index + 5 }}</wp:post_id>
-    <wp:post_date><![CDATA[{{ post.data.title | w3DateFilter }}]]></wp:post_date>
+    <wp:post_date><![CDATA[{{ postDate | w3DateFilter }}]]></wp:post_date>
     <wp:comment_status><![CDATA[closed]]></wp:comment_status>
     <wp:ping_status><![CDATA[closed]]></wp:ping_status>
     <wp:post_name><![CDATA[{{ post.fileSlug }}d]]></wp:post_name>
@@ -56,6 +67,7 @@ xmlns:wp="http://wordpress.org/export/1.2/"
     <wp:is_sticky>0</wp:is_sticky>
     <category domain="category" nicename="uncategorized"><![CDATA[Uncategorized]]></category>
   </item>
-  {% endfor %}
+
+  {%- endfor -%}
   </channel>
 </rss>


### PR DESCRIPTION
It seems some of the posts don't have dates, this would adjust the `w3cDate` filter to attempt to parse the date out of the string if it is invalid.

In the `wp.nkj` It has been adjusted to check if the date is present, if it is not present it passes in the file slug. 

I did add the filter to `pubDate` to element so it doesn't get the file name accidently. 